### PR TITLE
Mark HTML & SCSS as Vendored

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.scss linguist-vendored
+*.html linguist-vendored


### PR DESCRIPTION
Marked HTML & SCSS as Vendored to prevent people from thinking you're taking credit from the original author